### PR TITLE
Changed order of params in plaid_user 

### DIFF
--- a/app/controllers/argyle/callback_controller.rb
+++ b/app/controllers/argyle/callback_controller.rb
@@ -6,7 +6,7 @@ class Argyle::CallbackController < ApplicationController
   end
 
   def plaid_user
-    @plaid_user ||= Argyle.plaid_client::User.load(plaid_access_token, plaid_products)
+    @plaid_user ||= Argyle.plaid_client::User.load(plaid_products, plaid_access_token)
   end
 
   protected

--- a/app/controllers/argyle/callback_controller.rb
+++ b/app/controllers/argyle/callback_controller.rb
@@ -6,7 +6,7 @@ class Argyle::CallbackController < ApplicationController
   end
 
   def plaid_user
-    @plaid_user ||= Argyle.plaid_client::User.load(plaid_products, plaid_access_token)
+    @plaid_user ||= Argyle.plaid_client::User.load(plaid_products.to_sym, plaid_access_token)
   end
 
   protected

--- a/spec/controllers/argyle_callback_controller_spec.rb
+++ b/spec/controllers/argyle_callback_controller_spec.rb
@@ -25,7 +25,7 @@ describe Argyle::CallbackController do
     end
 
     it "calls Plaid.set_user method" do
-      expect(Argyle.plaid_client::User).to receive(:load).with('myAccessToken', ["auth"])
+      expect(Argyle.plaid_client::User).to receive(:load).with(["auth"], 'myAccessToken')
       controller.plaid_user
     end
   end


### PR DESCRIPTION
This is to match the new order in the plaid_ruby gem.
see https://github.com/plaid/plaid-ruby/blame/8706ce7641bc82aead2d90832bc5bd3697057eb7/UPGRADING.md#L17
